### PR TITLE
Fix/db schema dump error

### DIFF
--- a/lib/schema_comments.rb
+++ b/lib/schema_comments.rb
@@ -14,8 +14,6 @@ module SchemaComments
   autoload :SchemaDumper      , 'schema_comments/schema_dumper'
 
   mattr_accessor :yaml_path
-  self.yaml_path = Rails.root.join("db/schema_comments.yml").to_s if defined?(Rails) && Rails.root
-
   mattr_accessor :quiet
 
   class YamlError < StandardError

--- a/lib/schema_comments.rb
+++ b/lib/schema_comments.rb
@@ -1,9 +1,9 @@
 require 'active_support/core_ext/module'
 
+require 'schema_comments/version'
 require 'schema_comments/railtie'
 
 module SchemaComments
-  VERSION = File.read(File.expand_path("../../VERSION", __FILE__))
 
   autoload :Base              , 'schema_comments/base'
   autoload :ConnectionAdapters, 'schema_comments/connection_adapters'

--- a/lib/schema_comments/railtie.rb
+++ b/lib/schema_comments/railtie.rb
@@ -5,6 +5,7 @@ require 'rails'
 module SchemaScomments
   class Railtie < ::Rails::Railtie
     rake_tasks do
+      SchemaComments.yaml_path = Rails.root.join("db/schema_comments.yml").to_s
       require 'schema_comments/task'
     end
   end

--- a/lib/schema_comments/version.rb
+++ b/lib/schema_comments/version.rb
@@ -1,3 +1,3 @@
 module SchemaComments
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Because SchemaComments.yaml_path was nil in rails app,  set SchemaComments.yaml_path in Rails::Railtie .