### PR TITLE
rake db:schema:dump で一部エラーになっていたので修正しました

### DIFF
--- a/lib/schema_comments/schema_dumper.rb
+++ b/lib/schema_comments/schema_dumper.rb
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 module SchemaComments
   class SchemaDumper < ActiveRecord::SchemaDumper
+    include ActiveRecord::ConnectionAdapters::ColumnDumper # for schema_default
 
     autoload :Mysql, 'schema_comments/schema_dumper/mysql'
 
@@ -71,7 +72,8 @@ module SchemaComments
           spec[:precision] = column.precision.inspect if column.precision
           spec[:scale]     = column.scale.inspect if column.scale
           spec[:null]      = 'false' unless column.null
-          spec[:default]   = default_string(column.default) if column.has_default?
+          default = schema_default(column) if column.has_default?
+          spec[:default]   = schema_default(column) unless default.nil?
           spec[:comment]   = '"' << (column.comment || '').gsub(/\"/, '\"') << '"' # ここでinspectを使うと最後の文字だけ文字化け(UTF-8のコード)になっちゃう
           (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k.inspect} => ")}
           spec

--- a/lib/schema_comments/schema_dumper.rb
+++ b/lib/schema_comments/schema_dumper.rb
@@ -72,8 +72,8 @@ module SchemaComments
           spec[:precision] = column.precision.inspect if column.precision
           spec[:scale]     = column.scale.inspect if column.scale
           spec[:null]      = 'false' unless column.null
-          default = schema_default(column) if column.has_default?
-          spec[:default]   = schema_default(column) unless default.nil?
+          default = (!respond_to?(:schema_default) ? default_string(column.default) : schema_default(column)) if column.has_default?
+          spec[:default]   = default unless default.nil?
           spec[:comment]   = '"' << (column.comment || '').gsub(/\"/, '\"') << '"' # ここでinspectを使うと最後の文字だけ文字化け(UTF-8のコード)になっちゃう
           (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k.inspect} => ")}
           spec

--- a/lib/schema_comments/schema_dumper/mysql.rb
+++ b/lib/schema_comments/schema_dumper/mysql.rb
@@ -110,8 +110,8 @@ HEADER
           spec[:precision] = column.precision.inspect if column.precision
           spec[:scale]     = column.scale.inspect if column.scale
           spec[:null]      = 'false' unless column.null
-          default = schema_default(column) if column.has_default?
-          spec[:default]   = schema_default(column) unless default.nil?
+          default = !respond_to?(:schema_default) ? default_string(column.default) : schema_default(column) if column.has_default?
+          spec[:default]   = default unless default.nil?
           if column.name == pk
             spec[:comment]   = '"AUTO_INCREMENT PRIMARY KEY by rails"'
           else

--- a/lib/schema_comments/schema_dumper/mysql.rb
+++ b/lib/schema_comments/schema_dumper/mysql.rb
@@ -4,6 +4,7 @@ require 'schema_comments/schema_dumper'
 module SchemaComments
 
   class SchemaDumper::Mysql < SchemaComments::SchemaDumper
+    include ActiveRecord::ConnectionAdapters::ColumnDumper # for schema_default
 
     class << self
       public :new
@@ -109,7 +110,8 @@ HEADER
           spec[:precision] = column.precision.inspect if column.precision
           spec[:scale]     = column.scale.inspect if column.scale
           spec[:null]      = 'false' unless column.null
-          spec[:default]   = default_string(column.default) if column.has_default?
+          default = schema_default(column) if column.has_default?
+          spec[:default]   = schema_default(column) unless default.nil?
           if column.name == pk
             spec[:comment]   = '"AUTO_INCREMENT PRIMARY KEY by rails"'
           else

--- a/lib/schema_comments/schema_dumper/mysql.rb
+++ b/lib/schema_comments/schema_dumper/mysql.rb
@@ -6,6 +6,12 @@ module SchemaComments
   class SchemaDumper::Mysql < SchemaComments::SchemaDumper
     include ActiveRecord::ConnectionAdapters::ColumnDumper # for schema_default
 
+    if ActiveRecord.version < Gem::Version.new("4.2.0")
+      def schema_default(column)
+        default_string(column.default)
+      end
+    end
+
     class << self
       public :new
     end
@@ -110,7 +116,7 @@ HEADER
           spec[:precision] = column.precision.inspect if column.precision
           spec[:scale]     = column.scale.inspect if column.scale
           spec[:null]      = 'false' unless column.null
-          default = !respond_to?(:schema_default) ? default_string(column.default) : schema_default(column) if column.has_default?
+          default = schema_default(column) if column.has_default?
           spec[:default]   = default unless default.nil?
           if column.name == pk
             spec[:comment]   = '"AUTO_INCREMENT PRIMARY KEY by rails"'

--- a/spec/migrations/valid/001_create_products.rb
+++ b/spec/migrations/valid/001_create_products.rb
@@ -4,7 +4,7 @@ class CreateProducts < ActiveRecord::Migration
   def self.up
     create_table "products", :comment => '商品' do |t|
       t.string   "product_type_cd", :comment => '種別コード'
-      t.integer  "price", :comment => "価格"
+      t.integer  "price", :comment => "価格", default: 0
       t.string   "name", :comment => "商品名"
       t.datetime "created_at", :comment => "登録日時"
       t.datetime "updated_at", :comment => "更新日時"

--- a/spec/schema_comments/schema_dumper_spec.rb
+++ b/spec/schema_comments/schema_dumper_spec.rb
@@ -64,20 +64,20 @@ EOS
 
       if ENV['DB'] =~ /mysql/i
         s << <<EOS
-    #t.column "id",              "int(11)",      :null => false, :comment => "AUTO_INCREMENT PRIMARY KEY by rails"
-    t.column "product_type_cd", "varchar(255)",                 :comment => "種別コード"
-    t.column "price",           "int(11)",                      :comment => "価格"
-    t.column "name",            "varchar(255)",                 :comment => "商品名"
-    t.column "created_at",      "datetime",                     :comment => "登録日時"
-    t.column "updated_at",      "datetime",                     :comment => "更新日時"
+    #t.column "id",              "int(11)",                     :null => false, :comment => "AUTO_INCREMENT PRIMARY KEY by rails"
+    t.column "product_type_cd", "varchar(255)",                                :comment => "種別コード"
+    t.column "price",           "int(11)",      :default => 0,                 :comment => "価格"
+    t.column "name",            "varchar(255)",                                :comment => "商品名"
+    t.column "created_at",      "datetime",                                    :comment => "登録日時"
+    t.column "updated_at",      "datetime",                                    :comment => "更新日時"
 EOS
       else
         s << <<EOS
-    t.string   "product_type_cd", :comment => "種別コード"
-    t.integer  "price",           :comment => "価格"
-    t.string   "name",            :comment => "商品名"
-    t.datetime "created_at",      :comment => "登録日時"
-    t.datetime "updated_at",      :comment => "更新日時"
+    t.string   "product_type_cd",                :comment => "種別コード"
+    t.integer  "price",           :default => 0, :comment => "価格"
+    t.string   "name",                           :comment => "商品名"
+    t.datetime "created_at",                     :comment => "登録日時"
+    t.datetime "updated_at",                     :comment => "更新日時"
 EOS
       end
       s << <<EOS


### PR DESCRIPTION
defaultが設定されているカラムを含むターブルについては、db/schema.rbに以下のように出力されてしまうことがあったので、修正しました。

```
# Could not dump table "products" because of following NoMethodError
#   undefined method `default_string' for #<SchemaComments::SchemaDumper:0x007ff72305f1a0>
```
