### PR TITLE
fix a broken link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /pkg
 /selectable_attr_test.sqlite3.db
 /Gemfile.lock
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-group :development do
+group :development, :test do
   gem "sqlite3"
   gem "mysql2"
   gem "rails"

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ rake db:annotate で以下のようなコメントを、モデル、テスト、
 annotate_modelsは、達人プログラマーのDave Thomasさんが公開しているプラグインです。
 http://repo.pragprog.com/svn/Public/plugins/annotate_models/
 
-本プラグインでは、それを更に拡張したDave Boltonさんのプラグイン(
-http://github.com/rotuka/annotate_models )をベースに拡張を加えています。
+本プラグインでは、それを更に拡張したDave Boltonさんのプラグインannotate_models
+( リポジトリは削除された様子・・・ )をベースに拡張を加えています。
 
 ## License
 Copyright (c) 2008 Takeshi AKIMA, released under the Ruby License

--- a/gemfiles/Gemfile.rails-4.0
+++ b/gemfiles/Gemfile.rails-4.0
@@ -5,7 +5,7 @@ gem "activerecord" , "~> 4.0.0"
 
 group :test do
   gem "sqlite3", :platform => :ruby
-  gem "mysql2" , :platform => :ruby
+  gem "mysql2" , "~> 0.3.13", :platform => :ruby
   gem "rails"
 
   # gem "activerecord-jdbcsqlite3-adapter", :platform => :jruby

--- a/gemfiles/Gemfile.rails-4.1
+++ b/gemfiles/Gemfile.rails-4.1
@@ -3,9 +3,9 @@ source "http://rubygems.org"
 gem "activesupport", "~> 4.1.0"
 gem "activerecord" , "~> 4.1.0"
 
-group :test do
+group :development, :test do
   gem "sqlite3", :platform => :ruby
-  gem "mysql2" , :platform => :ruby
+  gem "mysql2" , "~> 0.3.13", :platform => :ruby
   gem "rails"
 end
 


### PR DESCRIPTION
Dave Bolton's annotate_models repository can't be found now. It seems he removed his GitHub account.
