### PR TITLE
Fix a failure on ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 script: "bundle exec rake spec"
 rvm:
 #  - 2.0.0 # it can work but spec fails
-  - 2.1.6
-  - 2.2.2
+  - 2.1.10
+  - 2.2.4
+  - 2.3.0
 gemfile:
   - gemfiles/Gemfile.rails-4.0
   - gemfiles/Gemfile.rails-4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 script: "bundle exec rake spec"
 rvm:
-#  - 2.0.0 # it can work but spec fails
-  - 2.1.10
   - 2.2.4
   - 2.3.0
 gemfile:

--- a/spec/annotate_models_spec.rb
+++ b/spec/annotate_models_spec.rb
@@ -17,7 +17,7 @@ describe AnnotateModels do
   end
 
   it "get_schema_info" do
-    (ActiveRecord::Base.connection.tables - %w(schema_migrations)).should == []
+    expect(ActiveRecord::Base.connection.tables - %w(schema_migrations)).to eq []
 
     ActiveRecord::Schema.define(:version => "20090721185959") do
       drop_table("books") rescue nil
@@ -42,7 +42,8 @@ puts "ActiveRecord::Base.connection.adapter_name: #{ActiveRecord::Base.connectio
       else               ":integer   "
       end
 
-    AnnotateModels.get_schema_info(Book).should == %{# == Schema Info ==
+    expect(AnnotateModels.get_schema_info(Book)).to eq <<EOS
+# == Schema Info ==
 # 
 # Schema version: 20090721185959
 #
@@ -57,7 +58,8 @@ puts "ActiveRecord::Base.connection.adapter_name: #{ActiveRecord::Base.connectio
 # 
 # =================
 # 
-}
+EOS
+
   end
 
 end

--- a/spec/hash_key_orderable_spec.rb
+++ b/spec/hash_key_orderable_spec.rb
@@ -12,13 +12,13 @@ describe HashKeyOrderable do
       hash.each do |key, value|
         actuals << key
       end
-      actuals.should == hash.key_order
+      expect(actuals).to eq hash.key_order
     end
 
     it "should use original each without key_order" do
       hash = {'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4}
       hash.extend(HashKeyOrderable)
-      hash.should_receive(:each_without_key_order) # original each method
+      expect(hash).to receive(:each_without_key_order) # original each method
       hash.each{ }
     end
 
@@ -30,8 +30,8 @@ describe HashKeyOrderable do
       hash.each do |key, value|
         actuals << key
       end
-      actuals[0..2].should == hash.key_order
-      actuals[3..4].sort.should == %w(a c)
+      expect(actuals[0..2]).to eq hash.key_order
+      expect(actuals[3..4].sort).to eq %w(a c)
     end
 
     it "should ignore unexist key in key_order" do
@@ -42,8 +42,8 @@ describe HashKeyOrderable do
       hash.each do |key, value|
         actuals << key
       end
-      actuals[0..1].should == %w(b d)
-      actuals[2..4].sort.should == %w(a c e)
+      expect(actuals[0..1]).to eq %w(b d)
+      expect(actuals[2..4].sort).to eq %w(a c e)
     end
 
   end

--- a/spec/i18n_export_spec.rb
+++ b/spec/i18n_export_spec.rb
@@ -15,7 +15,7 @@ describe SchemaComments::Base do
   end
 
   it "test_valid_migration" do
-    (ActiveRecord::Base.connection.tables - %w(schema_migrations)).should == []
+    expect(ActiveRecord::Base.connection.tables - %w(schema_migrations)).to eq []
 
     migration_path = File.join(MIGRATIONS_ROOT, 'valid')
     Dir.glob('*.rb').each do |file|
@@ -26,19 +26,19 @@ describe SchemaComments::Base do
     Product.reset_column_comments
 
     ActiveRecord::Migrator.up(migration_path, 1)
-    ActiveRecord::Migrator.current_version.should == 1
+    expect(ActiveRecord::Migrator.current_version).to eq 1
 
-    ActiveRecord::Base.export_i18n_models.keys.include?('product').should == true
-    ActiveRecord::Base.export_i18n_models['product'].should == '商品'
+    expect(ActiveRecord::Base.export_i18n_models.keys.include?('product')).to eq true
+    expect(ActiveRecord::Base.export_i18n_models['product']).to eq '商品'
 
-    ActiveRecord::Base.export_i18n_attributes.keys.include?('product').should == true
-    ActiveRecord::Base.export_i18n_attributes['product'].should == {
+    expect(ActiveRecord::Base.export_i18n_attributes.keys.include?('product')).to eq true
+    expect(ActiveRecord::Base.export_i18n_attributes['product']).to eq({
           'product_type_cd' => '種別コード',
           "price" => "価格",
           "name" => "商品名",
           "created_at" => "登録日時",
           "updated_at" => "更新日時"
-        }
+        })
   end
 
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -15,7 +15,7 @@ describe ActiveRecord::Migrator do
   end
 
   it "test_valid_migration" do
-    (ActiveRecord::Base.connection.tables - %w(schema_migrations)).should == []
+    expect(ActiveRecord::Base.connection.tables - %w(schema_migrations)).to eq []
 
     migration_path = File.join(MIGRATIONS_ROOT, 'valid')
     Dir.glob('*.rb').each do |file|
@@ -27,8 +27,8 @@ describe ActiveRecord::Migrator do
 
     ActiveRecord::Migrator.up(migration_path, 1)
 
-    ActiveRecord::Migrator.current_version.should == 1
-    Product.table_comment.should == '商品'
+    expect(ActiveRecord::Migrator.current_version).to eq 1
+    expect(Product.table_comment).to eq '商品'
     {
       'product_type_cd' => '種別コード',
       "price" => "価格",
@@ -36,17 +36,17 @@ describe ActiveRecord::Migrator do
       "created_at" => "登録日時",
       "updated_at" => "更新日時"
     }.each do |col_name, comment|
-      Product.columns.detect{|c| c.name.to_s == col_name}.comment.should == comment
+      expect(Product.columns.detect{|c| c.name.to_s == col_name}.comment).to eq comment
     end
 
     ActiveRecord::Migrator.down(migration_path, 0)
-    # SchemaComments::SchemaComment.count.should == 0
+    # expect(SchemaComments::SchemaComment.count).to eq 0
 
     ActiveRecord::Migrator.up(migration_path, 1)
     ActiveRecord::Migrator.up(migration_path, 2)
-    ActiveRecord::Migrator.current_version.should == 2
+    expect(ActiveRecord::Migrator.current_version).to eq 2
 
-    ProductName.table_comment.should == '商品'
+    expect(ProductName.table_comment).to eq '商品'
     {
       'product_type_cd' => '種別コード',
       "price" => "価格",
@@ -54,13 +54,13 @@ describe ActiveRecord::Migrator do
       "created_at" => "登録日時",
       "updated_at" => "更新日時"
     }.each do |col_name, comment|
-      ProductName.columns.detect{|c| c.name == col_name}.comment.should == comment
+      expect(ProductName.columns.detect{|c| c.name == col_name}.comment).to eq comment
     end
 
     ActiveRecord::Migrator.down(migration_path, 1)
-    ActiveRecord::Migrator.current_version.should == 1
+    expect(ActiveRecord::Migrator.current_version).to eq 1
 
-    Product.table_comment.should == '商品'
+    expect(Product.table_comment).to eq '商品'
     {
       'product_type_cd' => '種別コード',
       "price" => "価格",
@@ -68,25 +68,25 @@ describe ActiveRecord::Migrator do
       "created_at" => "登録日時",
       "updated_at" => "更新日時"
     }.each do |col_name, comment|
-      Product.columns.detect{|c| c.name == col_name}.comment.should == comment
+      expect(Product.columns.detect{|c| c.name == col_name}.comment).to eq comment
     end
 
     ActiveRecord::Migrator.up(migration_path, 4)
-    ActiveRecord::Migrator.current_version.should == 4
-    # SchemaComments::SchemaComment.count.should == 5
+    expect(ActiveRecord::Migrator.current_version).to eq 4
+    # expect(SchemaComments::SchemaComment.count).to eq 5
 
     ActiveRecord::Migrator.down(migration_path, 3)
-    ActiveRecord::Migrator.current_version.should == 3
-    # SchemaComments::SchemaComment.count.should == 6
+    expect(ActiveRecord::Migrator.current_version).to eq 3
+    # expect(SchemaComments::SchemaComment.count).to eq 6
 
     ActiveRecord::Migrator.up(migration_path, 5)
-    ActiveRecord::Migrator.current_version.should == 5
-    Product.columns.detect{|c| c.name == 'name'}.comment.should == '商品名'
+    expect(ActiveRecord::Migrator.current_version).to eq 5
+    expect(Product.columns.detect{|c| c.name == 'name'}.comment).to eq '商品名'
 
     ActiveRecord::Migrator.up(migration_path, 6)
-    ActiveRecord::Migrator.current_version.should == 6
+    expect(ActiveRecord::Migrator.current_version).to eq 6
     Product.reset_column_comments
-    Product.columns.detect{|c| c.name == 'name'}.comment.should == '名称'
+    expect(Product.columns.detect{|c| c.name == 'name'}.comment).to eq '名称'
 
     # Bug report from Ishikawa, Thanks!
     # schema_commentsのcolumn_commentsがうまく動かないみたいです。
@@ -96,13 +96,13 @@ describe ActiveRecord::Migrator do
     # column_comments(:table_name => {:column_name => "name"})
     # 上記のようにメソッドを呼び出しても、なぜか引数がHashではなくStringで取れてしまうみたいです。
     ActiveRecord::Migrator.up(migration_path, 7)
-    ActiveRecord::Migrator.current_version.should == 7
+    expect(ActiveRecord::Migrator.current_version).to eq 7
     Product.reset_column_comments
-    Product.columns.detect{|c| c.name == 'name'}.comment.should == '商品名称'
-    Product.columns.detect{|c| c.name == 'product_type_cd'}.comment.should == 'カテゴリコード'
+    expect(Product.columns.detect{|c| c.name == 'name'}.comment).to eq '商品名称'
+    expect(Product.columns.detect{|c| c.name == 'product_type_cd'}.comment).to eq 'カテゴリコード'
 
     ActiveRecord::Migrator.up(migration_path, 8)
-    ActiveRecord::Migrator.current_version.should == 8
+    expect(ActiveRecord::Migrator.current_version).to eq 8
   end
 
 end

--- a/spec/schema_comments/connection_adapters_spec.rb
+++ b/spec/schema_comments/connection_adapters_spec.rb
@@ -13,7 +13,7 @@ describe SchemaComments::ConnectionAdapters do
     ActiveRecord::Base.connection.initialize_schema_migrations_table
     ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::Migrator.schema_migrations_table_name}"
 
-    (ActiveRecord::Base.connection.tables - %w(schema_migrations)).should == []
+    expect(ActiveRecord::Base.connection.tables - %w(schema_migrations)).to eq []
 
     migration_path = File.join(MIGRATIONS_ROOT, 'valid')
     Dir.glob('*.rb').each do |file|
@@ -24,29 +24,29 @@ describe SchemaComments::ConnectionAdapters do
     Product.reset_column_comments
 
     ActiveRecord::Migrator.up(migration_path, 1)
-    ActiveRecord::Migrator.current_version.should == 1
+    expect(ActiveRecord::Migrator.current_version).to eq 1
 
-    ActiveRecord::Base.export_i18n_models.keys.include?('product').should == true
-    ActiveRecord::Base.export_i18n_models['product'].should == '商品'
+    expect(ActiveRecord::Base.export_i18n_models.keys.include?('product')).to eq true
+    expect(ActiveRecord::Base.export_i18n_models['product']).to eq '商品'
 
-    ActiveRecord::Base.export_i18n_attributes.keys.include?('product').should == true
-    ActiveRecord::Base.export_i18n_attributes['product'].should == {
+    expect(ActiveRecord::Base.export_i18n_attributes.keys.include?('product')).to eq true
+    expect(ActiveRecord::Base.export_i18n_attributes['product']).to eq({
       'product_type_cd' => '種別コード',
       "price" => "価格",
       "name" => "商品名",
       "created_at" => "登録日時",
       "updated_at" => "更新日時"
-    }
+    })
   end
 
   describe SchemaComments::ConnectionAdapters::Column do
     describe :comment do
       it "should return comment" do
-        Product.columns.detect{|c| c.name == "product_type_cd"}.comment.should == '種別コード'
-        Product.columns.detect{|c| c.name == "price"}.comment.should == '価格'
-        Product.columns.detect{|c| c.name == "name"}.comment.should == '商品名'
-        Product.columns.detect{|c| c.name == "created_at"}.comment.should == '登録日時'
-        Product.columns.detect{|c| c.name == "updated_at"}.comment.should == '更新日時'
+        expect(Product.columns.detect{|c| c.name == "product_type_cd"}.comment).to eq '種別コード'
+        expect(Product.columns.detect{|c| c.name == "price"}.comment).to eq '価格'
+        expect(Product.columns.detect{|c| c.name == "name"}.comment).to eq '商品名'
+        expect(Product.columns.detect{|c| c.name == "created_at"}.comment).to eq '登録日時'
+        expect(Product.columns.detect{|c| c.name == "updated_at"}.comment).to eq '更新日時'
       end
     end
 

--- a/spec/schema_comments/schema_comment_spec.rb
+++ b/spec/schema_comments/schema_comment_spec.rb
@@ -41,7 +41,7 @@ describe SchemaComments::SchemaComment do
       Dir.glob('*.rb').each{|file| require(file) if /^\d+?_.*/ =~ file}
 
       ActiveRecord::Migrator.up(migration_path, 8)
-      ActiveRecord::Migrator.current_version.should == 8
+      expect(ActiveRecord::Migrator.current_version).to eq 8
 
       SchemaComments.yaml_path =
         File.expand_path(File.join(
@@ -60,14 +60,14 @@ describe SchemaComments::SchemaComment do
         Dir.glob('*.rb').each{|file| require(file) if /^\d+?_.*/ =~ file}
 
         ActiveRecord::Migrator.up(migration_path, 8)
-        ActiveRecord::Migrator.current_version.should == 8
+        expect(ActiveRecord::Migrator.current_version).to eq 8
 
         SchemaComments.yaml_path =
           File.expand_path(File.join(
             File.dirname(__FILE__), "schema_comments_broken_#{broken_type}.yml"))
-        lambda{
+        expect{
           SchemaComments::SchemaComment.yaml_access(&proc)
-        }.should raise_error(SchemaComments::YamlError)
+        }.to raise_error(SchemaComments::YamlError)
       end
     end
 

--- a/spec/schema_comments/schema_dumper_spec.rb
+++ b/spec/schema_comments/schema_dumper_spec.rb
@@ -16,7 +16,7 @@ describe ActiveRecord::SchemaDumper do
 
   describe :dump do
     it "products" do
-      (ActiveRecord::Base.connection.tables - %w(schema_migrations)).should == []
+      expect(ActiveRecord::Base.connection.tables - %w(schema_migrations)).to eq []
 
       migration_path = File.join(MIGRATIONS_ROOT, 'valid')
       Dir.glob('*.rb').each{|file| require(file) if /^\d+?_.*/ =~ file}
@@ -25,19 +25,19 @@ describe ActiveRecord::SchemaDumper do
       Product.reset_column_comments
 
       ActiveRecord::Migrator.up(migration_path, 1)
-      ActiveRecord::Migrator.current_version.should == 1
+      expect(ActiveRecord::Migrator.current_version).to eq 1
 
-      ActiveRecord::Base.export_i18n_models.keys.include?('product').should == true
-      ActiveRecord::Base.export_i18n_models['product'].should == '商品'
+      expect(ActiveRecord::Base.export_i18n_models.keys.include?('product')).to eq true
+      expect(ActiveRecord::Base.export_i18n_models['product']).to eq '商品'
 
-      ActiveRecord::Base.export_i18n_attributes.keys.include?('product').should == true
-      ActiveRecord::Base.export_i18n_attributes['product'].should == {
+      expect(ActiveRecord::Base.export_i18n_attributes.keys.include?('product')).to eq true
+      expect(ActiveRecord::Base.export_i18n_attributes['product']).to eq({
         'product_type_cd' => '種別コード',
         "price" => "価格",
         "name" => "商品名",
         "created_at" => "登録日時",
         "updated_at" => "更新日時"
-      }
+      })
 
       dest = StringIO.new
       # ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, dest)
@@ -85,7 +85,7 @@ EOS
 
 end
 EOS
-      dest.read.should == s
+      expect(dest.read).to eq s
     end
 
   end

--- a/spec/yaml_export_spec.rb
+++ b/spec/yaml_export_spec.rb
@@ -31,7 +31,7 @@ describe SchemaComments::SchemaComment do
       end
     end
 
-    File.read(SchemaComments.yaml_path).split(/$/).map(&:strip).should == %{
+    expected = <<EOS
 ---
 table_comments:
   addresses: "住所"
@@ -49,7 +49,9 @@ column_comments:
   person:
     name: "名前"
     id: "人"
-}.split(/$/).map(&:strip)
+EOS
+    expected.gsub!('"', '') if Gem::Version.new(YAML::VERSION) >= Gem::Version.new("2.0.17")
+    expect(File.read(SchemaComments.yaml_path)).to eq expected
   end
 
 end


### PR DESCRIPTION
`YAML::VERSION` was changed from `2.0.8` to `2.0.17` between `ruby-2.2.4` to `ruby-2.3.0` .
'yaml-2.0.17` doesn't output usual string with double quotation marks. So I made `spec/yaml_export_spec.rb` consider `YAML::VERSION`.

And I fixed the spec files to use `expect` instead of `should`.

