### PR TITLE
Fix a bug in remove_column

### DIFF
--- a/lib/schema_comments/schema_comment.rb
+++ b/lib/schema_comments/schema_comment.rb
@@ -46,7 +46,7 @@ module SchemaComments
       def destroy_of(table_name, column_name)
         yaml_access do |db|
           column_hash = db[COLUMN_KEY][table_name.to_s]
-          column_hash.delete(column_name) if column_hash
+          column_hash.delete(column_name.to_s) if column_hash
         end
         @column_names = nil
       end

--- a/lib/schema_comments/version.rb
+++ b/lib/schema_comments/version.rb
@@ -1,3 +1,3 @@
 module SchemaComments
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -73,6 +73,8 @@ describe ActiveRecord::Migrator do
 
     ActiveRecord::Migrator.up(migration_path, 4)
     expect(ActiveRecord::Migrator.current_version).to eq 4
+    expect(SchemaComments::SchemaComment.column_comment('products', 'name')).to eq '商品名'
+    expect(SchemaComments::SchemaComment.column_comment('products', 'price')).to be_nil
     # expect(SchemaComments::SchemaComment.count).to eq 5
 
     ActiveRecord::Migrator.down(migration_path, 3)

--- a/spec/migrations/valid/004_remove_price.rb
+++ b/spec/migrations/valid/004_remove_price.rb
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 class RemovePrice < ActiveRecord::Migration
   def self.up
-    remove_column "products", "price"
+    # remove_column "products", "price"
+    remove_column "products", :price
   end
 
   def self.down


### PR DESCRIPTION
When the column name for remove_column was a Symbol, schema_comments didn't delete the comment for the key, and I fixed it.
